### PR TITLE
PG-7 Docker compose 추가, ReadMe 추가

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,0 +1,6 @@
+# Ginza API
+
+### Simple Docker Command
+* > docker-compose up -d
+* > docker ps 
+* > docker-compose down 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+version: "3.7" # 파일 규격 버전
+volumes:
+  ginza-dbdata:
+services:
+  # DB
+  postgresql:
+    image: "postgres:alpine"
+    container_name: ginza-db
+    restart: always
+    volumes:
+      - ginza-dbdata:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+    environment:
+      - POSTGRES_PASSWORD=password1234 # only local use
+      - POSTGRES_USER=ginza
+      - POSTGRES_DB=ginzadb
+      - TZ= "Asia/Seoul"
+  # Redis
+  redis:
+    image: redis:alpine
+    command: redis-server --port 6379
+    container_name: ginza-cache
+    hostname: localhost
+    labels:
+      - "name=redis"
+      - "mode=standalone"
+    ports:
+      - 6379:6379


### PR DESCRIPTION
* docker-compose 스크립트 추가(로컬 DB, cache 컨테이너 구성용)
  * 로컬에 PostgreSQL, Redis 인스턴스만 간단하게 띄우는 목적의 스크립트 입니다.
  * DB : 5432 / Redis : 6379
  * 실 연동은 장고 능력자분들께서 잘 해주실수 있으시리리라 믿구 있습니다..ㅎㅎ...
* ReadMe 추가

#### Jira Issue Ticket : https://marshallslee.atlassian.net/browse/PG-7
