### PR TITLE
[Draft] environ을 통한 민감 설정 외부화 적용, local에 대한 세팅 분리

### DIFF
--- a/ginza/settings/base.py
+++ b/ginza/settings/base.py
@@ -19,12 +19,6 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/3.2/howto/deployment/checklist/
 
-# SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'django-insecure-^69hq2n&x+j)a$(^a7_p6*b(-zfvl&(2ap+4a9)ql7m#awy4+3'
-
-# SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
-
 ALLOWED_HOSTS = []
 
 
@@ -68,18 +62,6 @@ TEMPLATES = [
 ]
 
 WSGI_APPLICATION = 'ginza.wsgi.application'
-
-
-# Database
-# https://docs.djangoproject.com/en/3.2/ref/settings/#databases
-
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': BASE_DIR / 'db.sqlite3',
-    }
-}
-
 
 # Password validation
 # https://docs.djangoproject.com/en/3.2/ref/settings/#auth-password-validators

--- a/ginza/settings/local.py
+++ b/ginza/settings/local.py
@@ -1,3 +1,4 @@
+from .base import *
 import environ, os
 
 env = environ.Env()

--- a/ginza/settings/local.py
+++ b/ginza/settings/local.py
@@ -1,0 +1,19 @@
+import environ, os
+
+env = environ.Env()
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# Take environment variables from .env file
+environ.Env.read_env(
+    env_file=os.path.join(BASE_DIR, '.env')
+)
+
+# SECURITY WARNING: don't run with debug turned on in production!
+DEBUG = env.bool('DEBUG')
+
+# SECURITY WARNING: keep the secret key used in production secret!
+SECRET_KEY = env.str('SECRET_KEY')
+
+# Database
+# https://docs.djangoproject.com/en/3.2/ref/settings/#databases
+DATABASES = {'default': env.db('DATABASE_URL')}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,7 @@
 Django==3.2.12
-djangorestframework==3.13.0
 django-environ==0.8.1
+djangorestframework==3.13.0
+env==0.1.0
+psycopg2==2.9.3
+pytz==2022.1
+sqlparse==0.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Django==3.2.12
 djangorestframework==3.13.0
+django-environ==0.8.1


### PR DESCRIPTION
변경사항
* 장고가 익숙하지 않아 바람직한 접근인지 확인을 요청드립니다.
* 공통 설정은 base.py에 두고, local에만 적용가능한 설정을 분리하였습니다.(추후 production setting 정보도 추가가 필요하겠네요)
* Secret-key나 DB 셋업 정보 같이 민감한 정보들을 settings.py에 그대로 노출시키는 부분에 이슈가 있어서 구글링을 통해 environ을 적용하였습니다.
 
실행
* command에 ```--settings=ginza.settings.local```  또는 environment variable에 ```DJANGO_SETTINGS_MODULE```에 ```ginza.settings.local```로 수정 (이 방식 외에 좀더 나은 방법이 있는지 궁금하네요) 
![image](https://user-images.githubusercontent.com/16380977/159169269-93473416-a18b-46dd-a65f-e855579dc118.png)

![image](https://user-images.githubusercontent.com/16380977/159169541-96d3f840-b5f1-4058-bca3-fa899a816ec3.png)


* 프로젝트 루트에 아래와 같은 내용의 ```.env``` 파일을 추가합니다.(이미 파일은 gitignore 되어 있네요)
```
DEBUG=True
SECRET_KEY=Auto-Generated-Hashed-Secret-Key
DATABASE_URL=psql://ginza:pasword1234@127.0.0.1:5432/ginzadb
```

참고
* https://cjh5414.github.io/django-settings-separate/
* https://django-environ.readthedocs.io/en/latest/
* https://djangostars.com/blog/configuring-django-settings-best-practices/