### PR TITLE
[PG-24] ginza-api 로그를 EFK(Elastic, Filebeat, Kibana) 스택과 연동

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 version: "3.7" # 파일 규격 버전
 volumes:
   ginza-dbdata:
+  ginza-elasticsearch:
 services:
   # DB
   postgresql:
@@ -27,3 +28,50 @@ services:
       - "mode=standalone"
     ports:
       - 6379:6379
+
+  # Elastic Search
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.15.2
+    container_name: ginza-elasticsearch
+    volumes:
+      - ginza-elasticsearch:/usr/share/elasticsearch/data
+    ports:
+      - "9200:9200"
+    environment:
+      - node.name=elasticsearch
+      - discovery.seed_hosts=elasticsearch
+      - cluster.initial_master_nodes=elasticsearch
+      - cluster.name=docker-cluster
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms256m -Xmx256m"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+        soft: 65535
+        hard: 65535
+
+  #kibana
+  kibana:
+    image: docker.elastic.co/kibana/kibana:7.15.2
+    container_name: ginza-kibana
+    environment:
+      ELASTICSEARCH_URL: http://elasticsearch:9200
+    ports:
+      - "5601:5601"
+
+  #filebeat
+  filebeat:
+    image: docker.elastic.co/beats/filebeat:7.15.2
+    command: filebeat -e -strict.perms=false
+    volumes:
+      - ./filebeat/filebeat.yml:/usr/share/filebeat/filebeat.yml:ro
+      - ./applogs:/usr/share/filebeat/logs
+    environment:
+      ELASTICSEARCH_URL: http://elasticsearch:9200
+    links:
+      - kibana
+      - elasticsearch
+    depends_on:
+      - elasticsearch

--- a/filebeat/filebeat.yml
+++ b/filebeat/filebeat.yml
@@ -1,0 +1,11 @@
+filebeat.inputs:
+- type: log
+  enabled: true
+  paths:
+    - /usr/share/filebeat/logs/*.log
+
+  multiline.pattern: '^\['
+  multiline.negate: true
+  multiline.match: after
+output.elasticsearch:
+  hosts: ["http://elasticsearch:9200"]

--- a/ginza/settings/local.py
+++ b/ginza/settings/local.py
@@ -76,7 +76,7 @@ LOGGING = {
             'style': '{',
         },
         'standard': {
-            'format': '%(asctime)s [%(levelname)s] %(name)s: %(message)s'
+            'format': '[%(asctime)s] %(levelname)s | %(funcName)s | %(name)s | %(message)s',
         },
     },
     'handlers': {
@@ -100,7 +100,7 @@ LOGGING = {
             'encoding': 'utf-8',
             'filters': ['require_debug_true'],
             'class': 'logging.handlers.RotatingFileHandler',
-            'filename': LOGGING_DIRECTORY + '/ginza.out',
+            'filename': LOGGING_DIRECTORY + '/ginza.log',
             'maxBytes': 1024 * 1024 * 5,
             'backupCount': 5,
             'formatter': 'standard',


### PR DESCRIPTION
### 변경사항
* api 로그를 Elastic Search와 연동하도록 local log 포맷 부분 변경
  *  elastic search 인덱싱을 위해 로그의 출력 포맷 및 확장자 변경
* 로컬에 EFK 인스턴스를 띄우기 위해 docker-compose.yml 수정

### Jira ticket
https://marshallslee.atlassian.net/browse/PG-24

## Elastic Search 컨테이너가 죽는 경우
### Windows
* 기본적으로 Docker desktop for Windows 환경을 구축하신 분들이라면 WSL 환경을 이미 구축했다고 가정하여 작성합니다.
* OS 기본으로 설정된 mmap 카운트 수치가 부족하여 발생되는 문제이므로, 아래 터미널 명령어를 통해 수치 변경
* Linux에서도 동일하게 ES 컨테이너가 죽는 현상이 발생한다면 mmap_count 수치를 한번 확인할 필요가 있습니다.
> wsl -d docker-desktop sysctl -w vm.max_map_count=262144

![화면 캡처 2022-04-06 230019](https://user-images.githubusercontent.com/16380977/161995727-88bf0f92-cafd-4a0a-9c62-c5026a2019f3.png)

### OSX(MacOS)
*  docker-desktop 설정에서 memory 수치를 늘려줍니다.
<img width="1261" alt="macos-docker-desktop-config" src="https://user-images.githubusercontent.com/16380977/161996789-d1b785f8-e830-49fa-838e-2995fb02e59f.png">


